### PR TITLE
Add macOS compatibility

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Cargo configuration for FF7 Landscaper
+# This file allows local development with path dependencies while using Git dependencies in production
+
+[patch."https://github.com/maciej-trebacz/ff7-lib.rs"]
+# Override the Git dependency with local path for development
+# This only works if the local path exists, otherwise falls back to Git
+ff7-lib = { path = "../ff7-lib" }

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ output
 *.sln
 *.sw?
 ~/.tauri/ff7-terraform.key
+
+# Cargo local development overrides
+.cargo/config.local.toml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "ff7-terraform",
-  "version": "0.6.0",
+  "name": "ff7-landscaper",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ff7-terraform",
-      "version": "0.6.0",
+      "name": "ff7-landscaper",
+      "version": "0.8.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-collapsible": "^1.1.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
-ff7-lib = { path = "../../ff7-lib" }
+ff7-lib = { git = "https://github.com/maciej-trebacz/ff7-lib.rs", branch = "main" }
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "nsis",
+    "targets": ["app"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
**ff7-landscaper**
- Update Tauri bundle targets for macOS (app instead of nsis)

**ff7-lib**
- Make winapi dependency Windows-only in ff7-lib
- Add platform-specific compilation guards for memory functions
- Fix process ID type conversion (u32 to i32)
- Add local development override with .cargo/config.toml (eg, in the main cargo, it was a path reference)